### PR TITLE
Make the BrowserSync / Gulp be more efficient and standalone

### DIFF
--- a/{{cookiecutter.theme_id}}/Gulpfile.js
+++ b/{{cookiecutter.theme_id}}/Gulpfile.js
@@ -15,7 +15,7 @@ gulp.task('watch', ['build'], function() {
     open: false,
   });
 
-  gulp.watch('templates/**/*.mustache')
+  gulp.watch('templates/**/*.mustache', reload);
   gulp.watch('scss/**/*.scss', ['sass']);
 });
 

--- a/{{cookiecutter.theme_id}}/Gulpfile.js
+++ b/{{cookiecutter.theme_id}}/Gulpfile.js
@@ -3,6 +3,9 @@ const $             = require('gulp-load-plugins')();
 const browserSync   = require('browser-sync').create();
 const reload        = browserSync.reload;
 
+// Match [[font:font-reference]]?v=1.2.3 and [[pix:pix-url]] for replacement
+const pattern       = new RegExp(/\[\[([^:]*):([^\]]+)\]\](\?v=([\d\.]+))?/, 'g');
+
 /**
  * Watching files for changes
  */
@@ -23,31 +26,33 @@ gulp.task('watch', ['build'], function() {
  * Write sourcemaps in dev mode
  */
 gulp.task('sass', function() {
-
-    return gulp.src('./scss/{{cookiecutter.theme_id}}.scss')
-      .pipe($.concat('compiled.scss'))
-      .pipe(gulp.dest('build/test'))
-      .pipe($.sourcemaps.init())
-      .pipe(
-        $.sass({
-          outputStyle: 'compressed',
-          includePaths: ['./scss']
-        })
-        .on('error', function(error) {
-          browserSync.sockets.emit('fullscreen:message', {
-            title: 'Sass compilation error',
-            body: error.message
-          });
-          $.sass.logError.apply(this, arguments);
-        })
-        .on('data', function(data) {
-          browserSync.sockets.emit('fullscreen:message:clear');
-        })
-      )
-      .pipe($.autoprefixer({cascade: false}))
-      .pipe($.sourcemaps.write('.'))
-      .pipe(gulp.dest('build/stylesheets'))
-      .pipe(reload({stream: true}));
+  return gulp.src('./scss/{{cookiecutter.theme_id}}.scss')
+    .pipe($.concat('compiled.scss'))
+    .pipe(gulp.dest('build/test'))
+    .pipe($.sourcemaps.init())
+    .pipe(
+      $.sass({
+        outputStyle: 'compressed',
+        includePaths: ['./scss']
+      })
+      .on('error', function(error) {
+        browserSync.sockets.emit('fullscreen:message', {
+          title: 'Sass compilation error',
+          body: error.message
+        });
+        $.sass.logError.apply(this, arguments);
+      })
+      .on('data', function(data) {
+        browserSync.sockets.emit('fullscreen:message:clear');
+      })
+    )
+    .pipe($.autoprefixer({cascade: false}))
+    .pipe($.replace(pattern, (match, p1, p2, p3, p4) => {
+      return `/theme/{{cookiecutter.theme_id}}/gulpfiles.php?${p1}=${p2}&v=${p4}`;
+    }))
+    .pipe($.sourcemaps.write('.'))
+    .pipe(gulp.dest('build/stylesheets'))
+    .pipe(reload({stream: true}));
 });
 
 

--- a/{{cookiecutter.theme_id}}/classes/output/core_renderer.php
+++ b/{{cookiecutter.theme_id}}/classes/output/core_renderer.php
@@ -40,7 +40,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
         $output = parent::standard_head_html();
 
         // Allow custom head content while in development.
-        if (DEBUG_DEVELOPER && !empty($CFG->devel_custom_additional_head) ) {
+        if (debugging('', DEBUG_DEVELOPER) && !empty($CFG->devel_custom_additional_head) ) {
             $output .= $CFG->devel_custom_additional_head;
         }
 

--- a/{{cookiecutter.theme_id}}/config.php
+++ b/{{cookiecutter.theme_id}}/config.php
@@ -70,3 +70,6 @@ $THEME->addblockposition = BLOCK_ADDBLOCK_POSITION_FLATNAV;
 $THEME->scss = function($theme) {
     return theme_{{cookiecutter.theme_id}}_get_main_scss_content($theme);
 };
+
+// This is the function that postprocesses CSS (as string). It is specified to allow entirely wiping CSS when Gulp is in action.
+$THEME->csspostprocess = 'theme_{{cookiecutter.theme_id}}_csspostprocess';

--- a/{{cookiecutter.theme_id}}/config.php
+++ b/{{cookiecutter.theme_id}}/config.php
@@ -24,7 +24,7 @@
 // This line protects the file from being accessed by a URL directly.
 defined('MOODLE_INTERNAL') || die();
 
-// $THEME is defined before this page is included and we can define settings by adding properties to this global object.
+// Object $THEME is defined before this page is included and we can define settings by adding properties to this global object.
 
 // The first setting we need is the name of the theme. This should be the last part of the component name, and the same
 // as the directory name for our theme.

--- a/{{cookiecutter.theme_id}}/gulpfiles.php
+++ b/{{cookiecutter.theme_id}}/gulpfiles.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * {{cookiecutter.theme_name}} [[pix: and [[font: proxy script
+ *
+ * @package    theme_{{cookiecutter.theme_id}}
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// Disable moodle specific debug messages and any errors in output,
+// comment out when debugging or better look into error log!
+define('NO_DEBUG_DISPLAY', true);
+define('NO_UPGRADE_CHECK', true);
+define('NO_MOODLE_COOKIES', true);
+
+require('../../config.php');
+
+$pix  = optional_param('pix', '', PARAM_TEXT);
+$font = optional_param('font', '', PARAM_TEXT);
+
+$theme = theme_config::load('{{cookiecutter.theme_id}}');
+
+// From lib/outputlib.php's post_process.php.
+
+// Resolve image locations.
+if (preg_match('/([a-z0-9_]+\|)?([^\]]+)/', $pix, $match)) {
+
+    $imagename = $match[2];
+    $component = rtrim($match[1], '|');
+    $imageurl = $theme->image_url($imagename, $component)->out(false);
+    // We do not need full url because the image.php is always in the same dir.
+    $imageurl = preg_replace('|^http.?://[^/]+|', '', $imageurl);
+    redirect($imageurl);
+}
+
+// Resolve font locations.
+if (preg_match('/([a-z0-9_]+\|)?([^\]]+)/', $font, $match)) {
+    $fontname = $match[2];
+    $component = rtrim($match[1], '|');
+    $fonturl = $theme->font_url($fontname, $component)->out(false);
+    // We do not need full url because the font.php is always in the same dir.
+    $fonturl = preg_replace('|^http.?://[^/]+|', '', $fonturl);
+    redirect($fonturl);
+}
+
+header('HTTP/1.0 404 Not found');

--- a/{{cookiecutter.theme_id}}/gulpfiles.php
+++ b/{{cookiecutter.theme_id}}/gulpfiles.php
@@ -35,9 +35,17 @@ $v    = optional_param('v', '', PARAM_TEXT);
 
 $theme = theme_config::load('{{cookiecutter.theme_id}}');
 
+$postfix = '';
+$prefix = '';
+
 if ($v) {
     // Cope with eventual versioning.
-    $v = '?v=' . $v;
+    $postfix = '?v=' . $v;
+}
+
+// Add Browsersync URL prefix.
+if (DEBUG_DEVELOPER && strpos($CFG->devel_custom_additional_head, 'build/stylesheets/compiled.css') !== false) {
+    $prefix = $CFG->wwwroot . ':3000';
 }
 
 // From lib/outputlib.php's post_process.php.
@@ -50,7 +58,7 @@ if (preg_match('/([a-z0-9_]+\|)?([^\]]+)/', $pix, $match)) {
     $imageurl = $theme->image_url($imagename, $component)->out(false);
     // We do not need full url because the image.php is always in the same dir.
     $imageurl = preg_replace('|^http.?://[^/]+|', '', $imageurl);
-    redirect($imageurl . $v);
+    redirect($prefix . $imageurl . $postfix);
 }
 
 // Resolve font locations.
@@ -60,7 +68,7 @@ if (preg_match('/([a-z0-9_]+\|)?([^\]]+)/', $font, $match)) {
     $fonturl = $theme->font_url($fontname, $component)->out(false);
     // We do not need full url because the font.php is always in the same dir.
     $fonturl = preg_replace('|^http.?://[^/]+|', '', $fonturl);
-    redirect($fonturl . $v);
+    redirect($prefix . $fonturl . $postfix);
 }
 
 header('HTTP/1.0 404 Not found');

--- a/{{cookiecutter.theme_id}}/gulpfiles.php
+++ b/{{cookiecutter.theme_id}}/gulpfiles.php
@@ -31,8 +31,14 @@ require('../../config.php');
 
 $pix  = optional_param('pix', '', PARAM_TEXT);
 $font = optional_param('font', '', PARAM_TEXT);
+$v    = optional_param('v', '', PARAM_TEXT);
 
 $theme = theme_config::load('{{cookiecutter.theme_id}}');
+
+if ($v) {
+    // Cope with eventual versioning.
+    $v = '?v=' . $v;
+}
 
 // From lib/outputlib.php's post_process.php.
 
@@ -44,7 +50,7 @@ if (preg_match('/([a-z0-9_]+\|)?([^\]]+)/', $pix, $match)) {
     $imageurl = $theme->image_url($imagename, $component)->out(false);
     // We do not need full url because the image.php is always in the same dir.
     $imageurl = preg_replace('|^http.?://[^/]+|', '', $imageurl);
-    redirect($imageurl);
+    redirect($imageurl . $v);
 }
 
 // Resolve font locations.
@@ -54,7 +60,7 @@ if (preg_match('/([a-z0-9_]+\|)?([^\]]+)/', $font, $match)) {
     $fonturl = $theme->font_url($fontname, $component)->out(false);
     // We do not need full url because the font.php is always in the same dir.
     $fonturl = preg_replace('|^http.?://[^/]+|', '', $fonturl);
-    redirect($fonturl);
+    redirect($fonturl . $v);
 }
 
 header('HTTP/1.0 404 Not found');

--- a/{{cookiecutter.theme_id}}/lib.php
+++ b/{{cookiecutter.theme_id}}/lib.php
@@ -120,7 +120,7 @@ function theme_{{cookiecutter.theme_id}}_update_settings_images($settingname) {
 /**
  * If we're designing the theme, empty the CSS styles output by styles_debug.php
  * Conditions:
- *    - $CFG->designermode = true;
+ *    - Debugging level is at least DEBUG_DEVELOPER
  *    - $CFG->devel_custom_additional_head contains 'build/stylesheets/compiled.css'
  *
  * @param $style Input CSS
@@ -128,8 +128,9 @@ function theme_{{cookiecutter.theme_id}}_update_settings_images($settingname) {
 function theme_{{cookiecutter.theme_id}}_csspostprocess($css) {
     global $CFG;
 
-    if (strpos($CFG->devel_custom_additional_head, 'build/stylesheets/compiled.css') !== false) {
+    if (debugging('', DEBUG_DEVELOPER) && strpos($CFG->devel_custom_additional_head, 'build/stylesheets/compiled.css') !== false) {
         // If we're designing the theme and we have an overlay for gulp, empty all CSS.
         return "head.see-compiled-css-by-gulp { color: white; }";
     }
+    return $css;
 }

--- a/{{cookiecutter.theme_id}}/lib.php
+++ b/{{cookiecutter.theme_id}}/lib.php
@@ -117,3 +117,19 @@ function theme_{{cookiecutter.theme_id}}_update_settings_images($settingname) {
     theme_reset_all_caches();
 }
 
+/**
+ * If we're designing the theme, empty the CSS styles output by styles_debug.php
+ * Conditions:
+ *    - $CFG->designermode = true;
+ *    - $CFG->devel_custom_additional_head contains 'build/stylesheets/compiled.css'
+ *
+ * @param $style Input CSS
+ */
+function theme_{{cookiecutter.theme_id}}_csspostprocess($css) {
+    global $CFG;
+
+    if (strpos($CFG->devel_custom_additional_head, 'build/stylesheets/compiled.css') !== false) {
+        // If we're designing the theme and we have an overlay for gulp, empty all CSS.
+        return "head.see-compiled-css-by-gulp { color: white; }";
+    }
+}

--- a/{{cookiecutter.theme_id}}/lib.php
+++ b/{{cookiecutter.theme_id}}/lib.php
@@ -82,7 +82,6 @@ function theme_{{cookiecutter.theme_id}}_update_settings_images($settingname) {
     // This is the component name the setting is stored in.
     $component = 'theme_{{cookiecutter.theme_id}}';
 
-
     // This is the value of the admin setting which is the filename of the uploaded file.
     $filename = get_config($component, $settingname);
     // We extract the file extension because we want to preserve it.

--- a/{{cookiecutter.theme_id}}/package.json
+++ b/{{cookiecutter.theme_id}}/package.json
@@ -8,6 +8,7 @@
     "gulp-autoprefixer": "^3.1.1",
     "gulp-concat": "^2.6.1",
     "gulp-load-plugins": "^1.5.0",
+    "gulp-replace": "^0.6.1",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.6.0"
   }

--- a/{{cookiecutter.theme_id}}/settings.php
+++ b/{{cookiecutter.theme_id}}/settings.php
@@ -60,7 +60,7 @@ if ($ADMIN->fulltree) {
 
     // Preset files setting.
     $name = 'theme_{{cookiecutter.theme_id}}/presetfiles';
-    $title = get_string('presetfiles','theme_{{cookiecutter.theme_id}}');
+    $title = get_string('presetfiles', 'theme_{{cookiecutter.theme_id}}');
     $description = get_string('presetfiles_desc', 'theme_{{cookiecutter.theme_id}}');
 
     $setting = new admin_setting_configstoredfile($name, $title, $description, 'preset', 0,


### PR DESCRIPTION
- When Gulp's CSS is used, empty all other theme CSS through a `csspostprocess` function. It allows the Gulp-provided CSS file to be the only one in use.
- Replaces the `[[font:…]]` and `[[pix:…]]` pseudo-URLs with URLs to `gulpfiles.php` which redirects to the correct Moodle URLs, eventually with a full BrowserSync URL.