### PR TITLE
Include plugins css

### DIFF
--- a/{{cookiecutter.theme_id}}/config.php
+++ b/{{cookiecutter.theme_id}}/config.php
@@ -38,4 +38,3 @@ $THEME->addblockposition = BLOCK_ADDBLOCK_POSITION_FLATNAV;
 $THEME->scss = function($theme) {
     return theme_{{cookiecutter.theme_id}}_get_main_scss_content($theme);
 };
-$THEME->csspostprocess = 'theme_{{cookiecutter.theme_id}}_csspostprocess';

--- a/{{cookiecutter.theme_id}}/lib.php
+++ b/{{cookiecutter.theme_id}}/lib.php
@@ -32,25 +32,11 @@ defined('MOODLE_INTERNAL') || die();
  */
 function theme_{{cookiecutter.theme_id}}_get_main_scss_content($theme) {
     global $CFG;
-
-    return file_get_contents($CFG->dirroot . '/theme/{{cookiecutter.theme_id}}/scss/{{cookiecutter.theme_id}}.scss');
-}
-
-
-/**
- * If we're designing the theme, empty the CSS styles output by styles_debug.php
- * Conditions:
- *    - Debugging level is at least DEBUG_DEVELOPER
- *    - $CFG->devel_custom_additional_head contains 'build/stylesheets/compiled.css'
- *
- * @param $style Input CSS
- */
-function theme_{{cookiecutter.theme_id}}_csspostprocess($css) {
-    global $CFG;
-
+    
     if (debugging('', DEBUG_DEVELOPER) && strpos($CFG->devel_custom_additional_head, 'build/stylesheets/') !== false) {
         // If we're designing the theme and we have an overlay for gulp, empty all CSS.
         return "head.see-compiled-css-by-gulp { color: white; }";
     }
-    return $css;
+
+    return file_get_contents($CFG->dirroot . '/theme/{{cookiecutter.theme_id}}/scss/{{cookiecutter.theme_id}}.scss');
 }


### PR DESCRIPTION
Fix a side effect:
Skipping the `theme_fraisa_csspostprocess` when `devel_custom_additional_head` is used creates a side effect.
```php
function theme_{{cookiecutter.theme_id}}_csspostprocess($css) {	
    // ...	
     if (debugging('', DEBUG_DEVELOPER) && strpos($CFG->devel_custom_additional_head, 'build/stylesheets/') !== false) {	    if (debugging('', DEBUG_DEVELOPER) && strpos($CFG->devel_custom_additional_head, 'build/stylesheets/') !== false) {
        // If we're designing the theme and we have an overlay for gulp, empty all CSS.	        // If we're designing the theme and we have an overlay for gulp, empty all CSS.
        return "head.see-compiled-css-by-gulp { color: white; }";	        return "head.see-compiled-css-by-gulp { color: white; }";
    }	    }
    return $css;	
}
```

Some css are sideloaded by plugins. Ignoring the `csspostprocess` function don't allow plugins to load css.  It's best to ignore `get_main_scss_content` instead and still process other css.

Note that I did this PR directly on Github. Codestyle can be messy.